### PR TITLE
Fix daily streak reset after missed days

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,11 +351,19 @@
         }
 
         function updateStreak() {
-            const today = new Date().toDateString();
+            const todayDate = new Date();
+            const today = todayDate.toDateString();
             const lastVisit = localStorage.getItem('lastVisit');
             let streak = parseInt(localStorage.getItem('streak') || '0');
             if (lastVisit !== today) {
-                streak++;
+                if (lastVisit) {
+                    const lastDate = new Date(lastVisit);
+                    const diffTime = todayDate - lastDate;
+                    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+                    streak = diffDays === 1 ? streak + 1 : 1;
+                } else {
+                    streak = 1;
+                }
                 localStorage.setItem('streak', streak);
                 localStorage.setItem('lastVisit', today);
             }

--- a/prim3.html
+++ b/prim3.html
@@ -363,14 +363,23 @@
         }
 
         function updateStreak() {
-            const today = new Date().toDateString();
+            const todayDate = new Date();
+            const today = todayDate.toDateString();
             const lastVisit = localStorage.getItem('lastVisit');
-            streak = parseInt(localStorage.getItem('streak') || '0');
+            let stored = parseInt(localStorage.getItem('streak') || '0');
             if (lastVisit !== today) {
-                streak++;
-                localStorage.setItem('streak', streak);
+                if (lastVisit) {
+                    const lastDate = new Date(lastVisit);
+                    const diffTime = todayDate - lastDate;
+                    const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+                    stored = diffDays === 1 ? stored + 1 : 1;
+                } else {
+                    stored = 1;
+                }
+                localStorage.setItem('streak', stored);
                 localStorage.setItem('lastVisit', today);
             }
+            streak = stored;
             document.getElementById('streak').textContent = streak;
             return streak;
         }

--- a/tester8.html
+++ b/tester8.html
@@ -490,12 +490,19 @@ Report generated: ${new Date().toLocaleString()}
 
       // Daily streak handling (simple)
       function updateStreak() {
-        const today = new Date().toDateString();
+        const todayDate = new Date();
+        const today = todayDate.toDateString();
         const last = localStorage.getItem('dora_last_visit');
         let streak = parseInt(localStorage.getItem('dora_streak') || '0', 10) || 0;
         if (last !== today) {
-          // increment if last visit exists and was yesterday (simple approach: increment anyway if different)
-          streak = streak + 1;
+          if (last) {
+            const lastDate = new Date(last);
+            const diffTime = todayDate - lastDate;
+            const diffDays = Math.floor(diffTime / (1000 * 60 * 60 * 24));
+            streak = diffDays === 1 ? streak + 1 : 1;
+          } else {
+            streak = 1;
+          }
           localStorage.setItem('dora_last_visit', today);
           localStorage.setItem('dora_streak', String(streak));
         }


### PR DESCRIPTION
## Summary
- Correct streak tracking so it resets after a day is missed instead of always incrementing
- Apply the same streak reset logic to alternate HTML pages using different storage keys

## Testing
- `node -e "const fs=require('fs');const script=fs.readFileSync('index.html','utf8');const match=script.match(/function updateStreak\([^]*?return streak;\n        }/);eval(match[0]);const document={elements:{streak:{textContent:''}},getElementById(id){return this.elements[id];}};global.document=document;const localStorage={store:{},getItem(k){return this.store[k]||null;},setItem(k,v){this.store[k]=String(v);}};global.localStorage=localStorage;console.log('initial',updateStreak());console.log('same day',updateStreak());localStorage.setItem('lastVisit',new Date('2000-01-01').toDateString());localStorage.setItem('streak','5');console.log('after long gap',updateStreak());localStorage.setItem('lastVisit',new Date(Date.now()-24*3600*1000).toDateString());localStorage.setItem('streak','3');console.log('after one day gap',updateStreak());"`
- `node -e "const fs=require('fs');const script=fs.readFileSync('prim3.html','utf8');const decl=script.match(/let streak = 0;/)[0];const func=script.match(/function updateStreak\([^]*?return streak;\n        }/)[0];eval(decl+'\n'+func);const document={elements:{streak:{textContent:''}},getElementById(id){return this.elements[id];}};global.document=document;const localStorage={store:{},getItem(k){return this.store[k]||null;},setItem(k,v){this.store[k]=String(v);}};global.localStorage=localStorage;console.log('initial',updateStreak());console.log('same day',updateStreak());localStorage.setItem('lastVisit',new Date('2000-01-01').toDateString());localStorage.setItem('streak','5');streak=5;console.log('after long gap',updateStreak());localStorage.setItem('lastVisit',new Date(Date.now()-24*3600*1000).toDateString());localStorage.setItem('streak','3');streak=3;console.log('after one day gap',updateStreak());"`
- `node -e "const fs=require('fs');const script=fs.readFileSync('tester8.html','utf8');const match=script.match(/function updateStreak\([^]*?return streak;\n      }/);eval(match[0]);const document={elements:{streak:{textContent:''}},getElementById(id){return this.elements[id];}};global.document=document;const localStorage={store:{},getItem(k){return this.store[k]||null;},setItem(k,v){this.store[k]=String(v);}};global.localStorage=localStorage;console.log('initial',updateStreak());console.log('same day',updateStreak());localStorage.setItem('dora_last_visit',new Date('2000-01-01').toDateString());localStorage.setItem('dora_streak','5');console.log('after long gap',updateStreak());localStorage.setItem('dora_last_visit',new Date(Date.now()-24*3600*1000).toDateString());localStorage.setItem('dora_streak','3');console.log('after one day gap',updateStreak());"`

------
https://chatgpt.com/codex/tasks/task_e_68a55281060c832d832f948489a5f97b