### PR TITLE
fix: reject empty answers in ratios quiz

### DIFF
--- a/assets/quiz-ratios.js
+++ b/assets/quiz-ratios.js
@@ -9,7 +9,10 @@
     return {a:parts[0],b:parts[1],text:parts[0]+":"+parts[1]};
   }
   function parseIntInput(str){
-    const n=Number(str.trim());
+    if(!str) return null;
+    const trimmed=str.trim();
+    if(trimmed==='') return null;
+    const n=Number(trimmed);
     return Number.isInteger(n)?n:null;
   }
   function shuffle(arr){


### PR DESCRIPTION
## Summary
- ensure parseIntInput returns null for empty answers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a81b114c14832d9e0aac0c3af73109